### PR TITLE
feat: auto-run install-peers-cli on each yarn command. pretty important

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "docs:compile": "mkdir docstemp ; cp TOP.md docstemp/README.md ; concat-md docstemp > README.md && rm -rf docstemp",
     "docs": "rm -rf docstemp && yarn docs:lib && yarn docs:bin && yarn docs:compile",
     "prepublishOnly": "yarn build && yarn docs && git commit README.md -m \"docs: updating docs\" && git push",
-    "watch": "livelink watch"
+    "watch": "livelink watch",
+    "prepare": "install-peers"
   },
   "repository": {
     "type": "git",
@@ -38,6 +39,7 @@
     "concat-md": "^0.3.5",
     "git-branch-is": "^4.0.0",
     "husky": "^4.2.5",
+    "install-peers-cli": "^2.2.0",
     "typedoc": "^0.19.0",
     "typedoc-plugin-markdown": "^2.4.0",
     "typescript": "^4.0.2",
@@ -49,8 +51,7 @@
   ],
   "dependencies": {
     "commander": "^6.0.0",
-    "inquirer": "^7.3.3",
-    "install-peers-cli": "^2.2.0"
+    "inquirer": "^7.3.3"
   },
   "liveLink": {
     "ignoreMasks": [


### PR DESCRIPTION
Fixing how we work with auto-adding peer dependencies in development. This becomes important when we need dependencies around to build in typescript. 